### PR TITLE
move HaskellDo tutorial to

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,6 +22,7 @@ sections: [
     ['community', 'Community'],
     ['tutorial', 'Tutorials'],
     ['library', 'Libraries'],
+    ['help', 'Help wanted'],
     ['other', 'Other']
 ]
 

--- a/_drafts/2018-01-18-basic-setup.md
+++ b/_drafts/2018-01-18-basic-setup.md
@@ -1,0 +1,19 @@
+---
+layout: page
+title: "basic setup for the beginner tutorials"
+category: tutorial
+date: 2018-01-18 13:14:00
+---
+
+Welcome to the beginner tutorials. The basic development setup suggested below intends to provide a starting point for beginners and a starting point to follow the workflow used in the other tutorials. Feel free to ignore or use an alternative setup of your preference.
+
+## Dependencies
+
+- Haskell [Stack](https://haskell-lang.org/get-started) build system
+- [emacs](https://www.gnu.org/software/emacs/) editor/IDE
+- [Intero](https://haskell-lang.org/intero) Haskell interactive development extension for IDEs
+
+## Basic workflow
+
+- [reading a csv](http://howistart.org/posts/haskell/1/) Chris Allen has written a very approachable tutorial describing all the basic workflow from creating a Haskell project to reading a CSV file to summing how many *at bats* present in the file. It also showcases something that Haskell lets you more conveniently than other languages: streaming the data in constant memory.
+

--- a/_posts/2017-03-05-haskelldo-getting-started.md
+++ b/_posts/2017-03-05-haskelldo-getting-started.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: "Getting started with HaskellDO"
-category: tutorial
+category: help
 date: 2016-10-20 21:35:06
 ---
 


### PR DESCRIPTION
As I discussed with @NickSeagull, I think the `HaskellDo` tutorial belongs to something like a `Help wanted` section, as it is not currently usable as a Haskell IDE.

I plan to populate the `tutorial` section with a `Frames` basic tutorial and similar things. Also, I think it would be reasonable to link to resources on setting up `emacs` and other IDEs, where appropriate.