### PR TITLE
Add blank lines to the *Risk mitigation* roadmap section

### DIFF
--- a/_posts/2025-11-09-roadmap.md
+++ b/_posts/2025-11-09-roadmap.md
@@ -429,6 +429,7 @@ By 2027, DataHaskell will provide a high-performance, end-to-end data science to
 ## Risk Mitigation
 
 ### Technical Risks
+
 | Risk | Mitigation |
 |------|-----------|
 | Performance doesn't match Python | Early benchmarking, profiling, and optimization sprints |
@@ -436,6 +437,7 @@ By 2027, DataHaskell will provide a high-performance, end-to-end data science to
 | Breaking changes in dependencies | Conservative version bounds, testing matrix |
 
 ### Community Risks
+
 | Risk | Mitigation |
 |------|-----------|
 | Maintainer burnout | Distributed ownership, recognition program, funding support |
@@ -443,6 +445,7 @@ By 2027, DataHaskell will provide a high-performance, end-to-end data science to
 | Slow adoption | Marketing efforts, case studies, migration guides |
 
 ### Ecosystem Risks
+
 | Risk | Mitigation |
 |------|-----------|
 | GHC changes break libraries | Test against multiple GHC versions, engage with GHC team |


### PR DESCRIPTION
The tables in the *Risk mitigation* section were not rendering properly.